### PR TITLE
fix: Améliorer le script de build Netlify pour injection fiable de la…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,74 @@
 [build]
   # Installation Flutter et build avec gestion du cache
-  command = "if [ ! -d \"flutter\" ]; then git clone https://github.com/flutter/flutter.git -b stable; fi && export PATH=$PATH:$PWD/flutter/bin && flutter config --enable-web && flutter build web --release --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY --dart-define=OPENAI_API_KEY=$OPENAI_API_KEY && ls -la build/web/ && APP_BUILD_VERSION=${NETLIFY_BUILD_ID:-${COMMIT_REF:-$(date +%s)}} && sed -i.bak \"s|NETLIFY_SUPABASE_URL_PLACEHOLDER|$SUPABASE_URL|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_SUPABASE_ANON_KEY_PLACEHOLDER|$SUPABASE_ANON_KEY|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_FIREBASE_VAPID_KEY_PLACEHOLDER|$FIREBASE_VAPID_KEY|g\" build/web/index.html && sed -i.bak \"s|__APP_BUILD_VERSION__|$APP_BUILD_VERSION|g\" build/web/index.html && sed -i.bak \"s|__SW_VERSION__|$APP_BUILD_VERSION|g\" build/web/sw.js && rm -f build/web/index.html.bak build/web/sw.js.bak && echo \"Variables replaced successfully (build version: $APP_BUILD_VERSION, SW version updated)\""
+  command = """
+    # Step 1: Install Flutter if needed
+    if [ ! -d "flutter" ]; then
+      echo "📦 Installing Flutter..."
+      git clone https://github.com/flutter/flutter.git -b stable
+    fi
+
+    # Step 2: Configure Flutter
+    export PATH=$PATH:$PWD/flutter/bin
+    flutter config --enable-web
+
+    # Step 3: Build Flutter web app
+    echo "🔨 Building Flutter web app..."
+    flutter build web --release \
+      --dart-define=SUPABASE_URL=$SUPABASE_URL \
+      --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY \
+      --dart-define=OPENAI_API_KEY=$OPENAI_API_KEY
+
+    # Step 4: Verify build output
+    echo "📂 Build output:"
+    ls -la build/web/
+
+    # Step 5: Set version (try multiple Netlify variables)
+    echo "🔍 Checking available version variables..."
+    echo "   BUILD_ID=$BUILD_ID"
+    echo "   NETLIFY_BUILD_ID=$NETLIFY_BUILD_ID"
+    echo "   COMMIT_REF=$COMMIT_REF"
+    echo "   CONTEXT=$CONTEXT"
+
+    if [ -n "$BUILD_ID" ]; then
+      APP_BUILD_VERSION="$BUILD_ID"
+      echo "✅ Using BUILD_ID: $APP_BUILD_VERSION"
+    elif [ -n "$NETLIFY_BUILD_ID" ]; then
+      APP_BUILD_VERSION="$NETLIFY_BUILD_ID"
+      echo "✅ Using NETLIFY_BUILD_ID: $APP_BUILD_VERSION"
+    elif [ -n "$COMMIT_REF" ]; then
+      APP_BUILD_VERSION="$COMMIT_REF"
+      echo "⚠️ Using COMMIT_REF: $APP_BUILD_VERSION"
+    else
+      APP_BUILD_VERSION=$(date +%s%3N)
+      echo "⚠️ Using timestamp (milliseconds): $APP_BUILD_VERSION"
+    fi
+
+    # Step 6: Replace placeholders (without creating backup files)
+    echo "🔄 Replacing placeholders..."
+    sed -i "s|NETLIFY_SUPABASE_URL_PLACEHOLDER|$SUPABASE_URL|g" build/web/index.html
+    sed -i "s|NETLIFY_SUPABASE_ANON_KEY_PLACEHOLDER|$SUPABASE_ANON_KEY|g" build/web/index.html
+    sed -i "s|NETLIFY_FIREBASE_VAPID_KEY_PLACEHOLDER|$FIREBASE_VAPID_KEY|g" build/web/index.html
+    sed -i "s|__APP_BUILD_VERSION__|$APP_BUILD_VERSION|g" build/web/index.html
+    sed -i "s|__SW_VERSION__|$APP_BUILD_VERSION|g" build/web/sw.js
+
+    # Step 7: Verify replacement
+    echo "🔍 Verifying version replacement..."
+    if grep -q "__APP_BUILD_VERSION__" build/web/index.html; then
+      echo "❌ ERROR: Version placeholder was not replaced!"
+      exit 1
+    else
+      echo "✅ Version successfully set to: $APP_BUILD_VERSION"
+    fi
+
+    if grep -q "__SW_VERSION__" build/web/sw.js; then
+      echo "❌ ERROR: SW version placeholder was not replaced!"
+      exit 1
+    else
+      echo "✅ Service Worker version successfully updated"
+    fi
+
+    echo "🎉 Build completed successfully!"
+  """
   publish = "build/web"
 
 # Configuration des redirections pour SPA


### PR DESCRIPTION
… version

Problèmes identifiés:
- Le placeholder __APP_BUILD_VERSION__ n'était jamais remplacé
- Les utilisateurs voyaient un timestamp JS (Date.now()) au lieu du BUILD_ID
- Le badge affichait 1762255648409 au lieu du BUILD_ID Netlify
- Manque de debugging et validation

Solutions:
- Script de build multi-étapes avec logging détaillé
- Test de plusieurs variables (BUILD_ID, NETLIFY_BUILD_ID, COMMIT_REF)
- Suppression des fichiers .bak qui causaient des problèmes
- Vérification post-remplacement avec échec si non effectué
- Fallback robuste vers timestamp milliseconde si nécessaire

Le script affichera maintenant clairement quelle variable est utilisée et échouera explicitement si le remplacement ne fonctionne pas.

Fichiers modifiés:
- netlify.toml