### PR TITLE
fix: Corriger les erreurs MIME type sur Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,10 @@
 [build]
   # Installation Flutter et build avec gestion du cache
-  command = "if [ ! -d \"flutter\" ]; then git clone https://github.com/flutter/flutter.git -b stable; fi && export PATH=$PATH:$PWD/flutter/bin && flutter config --enable-web && flutter build web --release --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY --dart-define=OPENAI_API_KEY=$OPENAI_API_KEY && ls -la build/web/ && sed -i.bak \"s|NETLIFY_SUPABASE_URL_PLACEHOLDER|$SUPABASE_URL|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_SUPABASE_ANON_KEY_PLACEHOLDER|$SUPABASE_ANON_KEY|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_FIREBASE_VAPID_KEY_PLACEHOLDER|$FIREBASE_VAPID_KEY|g\" build/web/index.html && echo \"Variables replaced successfully\""
+  command = "if [ ! -d \"flutter\" ]; then git clone https://github.com/flutter/flutter.git -b stable; fi && export PATH=$PATH:$PWD/flutter/bin && flutter config --enable-web && flutter build web --release --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY --dart-define=OPENAI_API_KEY=$OPENAI_API_KEY && ls -la build/web/ && sed -i.bak \"s|NETLIFY_SUPABASE_URL_PLACEHOLDER|$SUPABASE_URL|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_SUPABASE_ANON_KEY_PLACEHOLDER|$SUPABASE_ANON_KEY|g\" build/web/index.html && sed -i.bak \"s|NETLIFY_FIREBASE_VAPID_KEY_PLACEHOLDER|$FIREBASE_VAPID_KEY|g\" build/web/index.html && echo \"// Production env.js (empty - values injected in index.html)\" > build/web/env.js && echo \"console.log('[env.js] Environment variables loaded from window.ENV');\" >> build/web/env.js && echo \"Variables replaced successfully\""
   publish = "build/web"
 
-# Configuration des redirections pour SPA
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+# IMPORTANT: L'ordre des redirections compte! Netlify applique la première règle qui matche.
+# Les règles spécifiques doivent être EN PREMIER, la règle générique /* EN DERNIER.
 
 # Redirections pour les assets statiques
 [[redirects]]
@@ -18,6 +15,56 @@
 [[redirects]]
   from = "/icons/*"
   to = "/icons/:splat"
+  status = 200
+
+# Ne pas rediriger les fichiers JavaScript vers index.html
+[[redirects]]
+  from = "/*.js"
+  to = "/:splat.js"
+  status = 200
+
+[[redirects]]
+  from = "/*.js.map"
+  to = "/:splat.js.map"
+  status = 200
+
+# Ne pas rediriger les fichiers CSS vers index.html
+[[redirects]]
+  from = "/*.css"
+  to = "/:splat.css"
+  status = 200
+
+# Ne pas rediriger les fichiers JSON (manifest, etc.)
+[[redirects]]
+  from = "/*.json"
+  to = "/:splat.json"
+  status = 200
+
+# Ne pas rediriger les fichiers d'images
+[[redirects]]
+  from = "/*.png"
+  to = "/:splat.png"
+  status = 200
+
+[[redirects]]
+  from = "/*.jpg"
+  to = "/:splat.jpg"
+  status = 200
+
+[[redirects]]
+  from = "/*.svg"
+  to = "/:splat.svg"
+  status = 200
+
+[[redirects]]
+  from = "/*.ico"
+  to = "/:splat.ico"
+  status = 200
+
+# Configuration des redirections pour SPA (EN DERNIER comme fallback)
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
   status = 200
 
 # Variables d'environnement
@@ -41,13 +88,22 @@
   [headers.values]
     Cache-Control = "public, max-age=86400"
 
-# Headers pour les fichiers JS/CSS
+# Headers pour les fichiers JS/CSS avec Content-Type explicite
 [[headers]]
   for = "/*.js"
   [headers.values]
+    Content-Type = "application/javascript; charset=utf-8"
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
   for = "/*.css"
   [headers.values]
+    Content-Type = "text/css; charset=utf-8"
     Cache-Control = "public, max-age=31536000, immutable"
+
+# Headers pour les fichiers JSON
+[[headers]]
+  for = "/*.json"
+  [headers.values]
+    Content-Type = "application/json; charset=utf-8"
+    Cache-Control = "public, max-age=86400"


### PR DESCRIPTION
Problèmes corrigés:
- env.js retournait text/html au lieu de application/javascript
- flutter_service_worker.js retournait text/html
- main.dart.js retournait text/html

Solutions appliquées:
1. Réorganiser les redirections dans netlify.toml
   - Règles spécifiques (*.js, *.css, etc.) EN PREMIER
   - Règle générique /* EN DERNIER comme fallback

2. Ajouter des redirections explicites pour:
   - *.js, *.js.map (JavaScript)
   - *.css (Styles)
   - *.json (Manifests)
   - *.png, *.jpg, *.svg, *.ico (Images)

3. Ajouter headers Content-Type explicites:
   - application/javascript pour *.js
   - text/css pour *.css
   - application/json pour *.json

4. Créer env.js automatiquement dans le build:
   - Fichier généré dans build/web/env.js
   - Évite l'erreur 404/MIME type en production

Impact:
✅ Les fichiers JS sont maintenant servis correctement ✅ Plus d'erreur "unsupported MIME type"
✅ Service Workers fonctionnent correctement
✅ Application charge normalement