### PR TITLE
fix: Remplacer DailyGrowth par ChallengeMe dans le splash screen

### DIFF
--- a/lib/presentation/splash_screen/splash_screen.dart
+++ b/lib/presentation/splash_screen/splash_screen.dart
@@ -384,7 +384,7 @@ class _SplashScreenState extends State<SplashScreen>
           ),
           SizedBox(height: 1.h),
           Text(
-            'DailyGrowth',
+            'ChallengeMe',
             style: GoogleFonts.inter(
               fontSize: 14.sp,
               fontWeight: FontWeight.w700,


### PR DESCRIPTION
Changement cosmétique pour refléter le nom de marque correct.

Le texte "DailyGrowth" affiché pendant le chargement de l'application a été remplacé par "ChallengeMe" pour correspondre au nom de l'application dans le manifest et le reste de l'interface.

Fichiers modifiés:
- lib/presentation/splash_screen/splash_screen.dart (ligne 387)