### PR TITLE
fix: Corriger erreurs 404 Service Worker et manifest.json

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -56,6 +56,14 @@
     echo "// Production env.js (empty - values injected in index.html)" > build/web/env.js
     echo "console.log('[env.js] Environment variables loaded from window.ENV');" >> build/web/env.js
 
+    # Step 7b: Ensure manifest.json is present in build output
+    if [ ! -f "build/web/manifest.json" ]; then
+      echo "⚠️ manifest.json missing in build, copying from web/"
+      cp web/manifest.json build/web/manifest.json
+    else
+      echo "✅ manifest.json is present in build output"
+    fi
+
     # Step 8: Verify replacement
     echo "🔍 Verifying version replacement..."
     if grep -q "__APP_BUILD_VERSION__" build/web/index.html; then
@@ -88,11 +96,6 @@
 [[redirects]]
   from = "/icons/*"
   to = "/icons/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/flutter_service_worker.js"
-  to = "/flutter_service_worker.js"
   status = 200
 
 [[redirects]]

--- a/web/index.html
+++ b/web/index.html
@@ -184,7 +184,7 @@
       _flutter.loader.loadEntrypoint({
         entrypointUrl: `main.dart.js?v=${versionToken}`,
         serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
+          serviceWorkerVersion: null, // Disable Flutter's default service worker - we use custom sw.js
         },
         onEntrypointLoaded: function(engineInitializer) {
           engineInitializer.initializeEngine().then(function(appRunner) {


### PR DESCRIPTION
Résout les erreurs de console lors du chargement de l'application PWA:
- flutter_service_worker.js 404
- manifest.json 404

Changements:
- Désactive le Service Worker par défaut de Flutter (serviceWorkerVersion: null) car nous utilisons un Service Worker personnalisé (sw.js) pour Firebase
- Ajoute une vérification dans le build Netlify pour s'assurer que manifest.json est présent dans la sortie de build
- Retire la redirection inutile pour flutter_service_worker.js du netlify.toml

Ces corrections permettent au système de notifications push de fonctionner correctement sur iOS PWA sans erreurs de console.