### PR TITLE
fix: Disable password autofill & update domain change messaging

### DIFF
--- a/lib/presentation/onboarding_flow/widgets/problematique_progress_selection_widget.dart
+++ b/lib/presentation/onboarding_flow/widgets/problematique_progress_selection_widget.dart
@@ -434,7 +434,7 @@ class _ProblematiqueProgressSelectionWidgetState extends State<ProblematiqueProg
                   ),
                   SizedBox(height: 2.h),
                   Text(
-                    'Suivez votre avancement pour chaque problématique. Objectif : 50 défis complétés par problématique.',
+                    'Suivez votre avancement pour chaque problématique. Le changement de problématique sera effectif le lendemain.',
                     style: TextStyle(
                       fontSize: 14.sp,
                       color: AppTheme.lightTheme.colorScheme.onSurface.withOpacity(0.7),

--- a/lib/presentation/reset_password/reset_password_screen.dart
+++ b/lib/presentation/reset_password/reset_password_screen.dart
@@ -142,6 +142,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
                 TextFormField(
                   controller: _passwordController,
                   obscureText: _obscurePassword,
+                  autofillHints: const [AutofillHints.newPassword],
+                  enableSuggestions: false,
+                  autocorrect: false,
                   decoration: InputDecoration(
                     labelText: 'Nouveau mot de passe',
                     hintText: 'Entrez votre nouveau mot de passe',
@@ -170,6 +173,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
                 TextFormField(
                   controller: _confirmPasswordController,
                   obscureText: _obscureConfirmPassword,
+                  autofillHints: const [AutofillHints.newPassword],
+                  enableSuggestions: false,
+                  autocorrect: false,
                   decoration: InputDecoration(
                     labelText: 'Confirmer le mot de passe',
                     hintText: 'Confirmez votre nouveau mot de passe',

--- a/lib/presentation/user_profile/widgets/life_domains_widget.dart
+++ b/lib/presentation/user_profile/widgets/life_domains_widget.dart
@@ -46,35 +46,12 @@ class LifeDomainsWidget extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Text(
-                    'Objectifs sélectionnés',
-                    style: AppTheme.lightTheme.textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w500,
-                      color: AppTheme.lightTheme.colorScheme.onSurface,
-                    ),
-                  ),
-                  SizedBox(width: 2.w),
-                  Tooltip(
-                    message: 'Un changement de problématique sera effectif 24h après la modification dans la plateforme',
-                    padding: EdgeInsets.all(3.w),
-                    textStyle: TextStyle(
-                      color: Colors.white,
-                      fontSize: 11.sp,
-                      fontWeight: FontWeight.w400,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.black87,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Icon(
-                      Icons.info_outline,
-                      size: 18.sp,
-                      color: AppTheme.lightTheme.colorScheme.primary.withOpacity(0.7),
-                    ),
-                  ),
-                ],
+              Text(
+                'Objectifs sélectionnés',
+                style: AppTheme.lightTheme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w500,
+                  color: AppTheme.lightTheme.colorScheme.onSurface,
+                ),
               ),
               TextButton(
                 onPressed: onEditTap,


### PR DESCRIPTION
PROBLÈMES RÉSOLUS:
1. ✅ Auto-remplissage intempestif mot de passe réinitialisation
2. ✅ Message confus "Objectif : 50 défis" dans modal Domaine de vie
3. ✅ Tooltip "i" redondant dans bloc Domaine de vie

CORRECTIONS APPLIQUÉES:

🔐 Reset Password Screen (reset_password_screen.dart):
- Ajout autofillHints: [AutofillHints.newPassword] sur les 2 champs
- Ajout enableSuggestions: false
- Ajout autocorrect: false → Indique aux gestionnaires de mots de passe que c'est un NOUVEAU mot de passe → Évite le pré-remplissage avec ancien mot de passe

🎯 Modal Domaine de vie (problematique_progress_selection_widget.dart):
- ❌ Supprimé: "Objectif : 50 défis complétés par problématique"
- ✅ Ajouté: "Le changement de problématique sera effectif le lendemain" → Message plus clair sur le délai de prise en compte

👤 Bloc Domaine de vie (life_domains_widget.dart):
- ❌ Supprimé tooltip info (ℹ️) avec message 24h → Information déplacée dans le modal (meilleur emplacement)

IMPACT:
- Meilleure UX réinitialisation mot de passe (pas de confusion)
- Message cohérent sur délai changement problématique
- Interface profil plus épurée