### PR TITLE
fix: Change button label from "Fermer" to "Sauvegarder" in note editor

### DIFF
--- a/lib/presentation/notes/note_edit_screen.dart
+++ b/lib/presentation/notes/note_edit_screen.dart
@@ -423,7 +423,7 @@ class _NoteEditScreenState extends State<NoteEditScreen> {
                   if (modificationText.isEmpty)
                     Spacer(),
                   
-                  // Bouton Fermer (sauvegarde auto)
+                  // Bouton Sauvegarder
                   TextButton(
                     onPressed: _isSaving ? null : () async {
                       await _saveNote();
@@ -450,7 +450,7 @@ class _NoteEditScreenState extends State<NoteEditScreen> {
                             ),
                           )
                         : Text(
-                            'Fermer',
+                            'Sauvegarder',
                             style: TextStyle(
                               color: Color(0xFF1A73E8),
                               fontSize: 14.sp,


### PR DESCRIPTION
PROBLÈME:
- Bouton "Fermer" pas assez explicite
- L'action réelle est de sauvegarder la note avant de fermer
- Peut créer confusion pour l'utilisateur

CORRECTION:
✅ Changement texte bouton: "Fermer" → "Sauvegarder" ✅ Commentaire mis à jour: "Bouton Sauvegarder"

IMPACT:
- Action du bouton plus claire pour l'utilisateur
- UX améliorée, plus explicite
- Cohérent avec le comportement (sauvegarde + fermeture)