### PR TITLE
refactor: Remplacer 'Tutoriel PWA' par 'Installation' dans l'onboarding

### DIFF
--- a/lib/presentation/onboarding_flow/widgets/onboarding_page_widget.dart
+++ b/lib/presentation/onboarding_flow/widgets/onboarding_page_widget.dart
@@ -38,7 +38,7 @@ class OnboardingPageWidget extends StatelessWidget {
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Text(
-                  'Tutoriel PWA – Étape $step/3',
+                  'Installation – Étape $step/3',
                   style: AppTheme.lightTheme.textTheme.labelMedium?.copyWith(
                     color: AppTheme.lightTheme.primaryColor,
                     fontWeight: FontWeight.w600,


### PR DESCRIPTION
Modification:
- 'Tutoriel PWA – Étape X/3' → 'Installation – Étape X/3'

Plus clair et sans jargon technique