### PR TITLE
fix: Désactiver le Service Worker par défaut de Flutter

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -40,10 +40,6 @@
   <title>ChallengeMe</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
   
@@ -212,8 +208,9 @@
 
       _flutter.loader.loadEntrypoint({
         entrypointUrl: `main.dart.js?v=${versionToken}`,
+        // Désactiver le Service Worker par défaut de Flutter car nous utilisons sw.js personnalisé
         serviceWorker: {
-          serviceWorkerVersion: null, // Disable Flutter's default service worker - we use custom sw.js
+          serviceWorkerVersion: null,
         },
         onEntrypointLoaded: function(engineInitializer) {
           engineInitializer.initializeEngine().then(function(appRunner) {


### PR DESCRIPTION
Le Service Worker par défaut de Flutter (flutter_service_worker.js) entrait en conflit avec notre Service Worker personnalisé (sw.js) qui gère Firebase Cloud Messaging.

Changements:
- Passer serviceWorker: null dans la config du loader Flutter
- Supprimer la variable serviceWorkerVersion inutilisée
- Garder uniquement sw.js pour gérer les notifications push

Cela devrait résoudre les erreurs 404 sur flutter_service_worker.js