### PR TITLE
fix: Corriger les erreurs de compilation

### DIFF
--- a/lib/presentation/notification_test/notification_test_screen.dart
+++ b/lib/presentation/notification_test/notification_test_screen.dart
@@ -75,15 +75,15 @@ class _NotificationTestScreenState extends State<NotificationTestScreen> {
     try {
       // Vérifier les permissions
       _addLog('🔍 Vérification des permissions...');
-      final hasPermission = await _webNotificationService!.requestPermission();
+      final permissionResult = await _webNotificationService!.requestPermission();
 
       setState(() {
-        _permissionStatus = hasPermission ? 'Accordée ✅' : 'Refusée ❌';
+        _permissionStatus = permissionResult == 'granted' ? 'Accordée ✅' : 'Refusée ❌';
       });
       _addLog('🔐 Permission: $_permissionStatus');
 
       // Récupérer le token FCM
-      if (hasPermission) {
+      if (permissionResult == 'granted') {
         _addLog('🔑 Récupération du token FCM...');
         final token = await _webNotificationService!.getFCMToken();
 
@@ -243,14 +243,15 @@ class _NotificationTestScreenState extends State<NotificationTestScreen> {
         await _webNotificationService!.showAchievementNotification(
           title: 'Premier test réussi !',
           description: 'Vous avez testé les notifications',
-          points: 10,
+          pointsEarned: 10,
         );
         _addLog('✅ Notification de succès web envoyée');
       } else {
         await _notificationService.sendAchievementNotification(
-          title: 'Premier test réussi !',
+          userId: 'test-user',
+          achievementName: 'Premier test réussi !',
           description: 'Vous avez testé les notifications',
-          points: 10,
+          pointsEarned: 10,
         );
         _addLog('✅ Notification de succès mobile envoyée');
       }

--- a/lib/presentation/test_push_notifications/test_push_notifications_screen.dart
+++ b/lib/presentation/test_push_notifications/test_push_notifications_screen.dart
@@ -567,7 +567,7 @@ class _TestPushNotificationsScreenState
       child: Text(
         text,
         style: TextStyle(
-          color: color.shade800,
+          color: color,
           fontWeight: FontWeight.w500,
           fontSize: 13,
         ),

--- a/lib/services/simple_web_notification_service.dart
+++ b/lib/services/simple_web_notification_service.dart
@@ -32,6 +32,30 @@ class SimpleWebNotificationService {
         debugPrint('💡 Notifications require: Safari → Share → Add to Home Screen');
       }
 
+      // Vérifier permissions actuelles
+      if (_isNotificationSupported()) {
+        _permission = await _getNotificationPermission();
+        debugPrint('🔔 Current notification permission: $_permission');
+        
+        if (_permission == 'denied' && isIOS) {
+          debugPrint('❌ iOS: Permissions denied. Check Settings → ChallengeMe → Notifications');
+        }
+      } else {
+        _permission = 'denied';
+        debugPrint('⚠️ Notifications not supported on this browser');
+      }
+
+      // Enregistrer le service worker
+      await _registerServiceWorker();
+
+      _isInitialized = true;
+      debugPrint('✅ Simple Web Notification Service initialized successfully');
+    } catch (e) {
+      debugPrint('❌ Failed to initialize Simple Web Notification Service: $e');
+    }
+  }
+
+  /// Demande de permission avec support legacy callback
   Future<String> _requestPermissionLegacyWithCallback() async {
     try {
       final notification = js.context['Notification'];
@@ -90,29 +114,6 @@ class SimpleWebNotificationService {
     } catch (e) {
       debugPrint('❌ Legacy permission fallback failed: $e');
       return 'default';
-    }
-  }
-
-      // Vérifier permissions actuelles
-      if (_isNotificationSupported()) {
-        _permission = await _getNotificationPermission();
-        debugPrint('🔔 Current notification permission: $_permission');
-        
-        if (_permission == 'denied' && isIOS) {
-          debugPrint('❌ iOS: Permissions denied. Check Settings → ChallengeMe → Notifications');
-        }
-      } else {
-        _permission = 'denied';
-        debugPrint('⚠️ Notifications not supported on this browser');
-      }
-
-      // Enregistrer le service worker
-      await _registerServiceWorker();
-
-      _isInitialized = true;
-      debugPrint('✅ Simple Web Notification Service initialized successfully');
-    } catch (e) {
-      debugPrint('❌ Failed to initialize Simple Web Notification Service: $e');
     }
   }
 


### PR DESCRIPTION
Correction de 3 fichiers pour résoudre les erreurs de build Flutter :

1. notification_test_screen.dart:
   - Correction du type de retour de requestPermission() (String au lieu de bool)
   - Fix des paramètres pour sendAchievementNotification (userId, achievementName, pointsEarned)

2. test_push_notifications_screen.dart:
   - Correction de color.shade800 vers color (Color n'a pas de shade)

3. simple_web_notification_service.dart:
   - Extraction de _requestPermissionLegacyWithCallback() hors de initialize()
   - Restructuration correcte comme méthode de classe

Ces corrections permettront au build Flutter de réussir sur Netlify.