### PR TITLE
fix: Corriger les erreurs de notifications sur iOS Safari PWA

### DIFF
--- a/lib/presentation/notification_test/notification_test_screen.dart
+++ b/lib/presentation/notification_test/notification_test_screen.dart
@@ -91,14 +91,18 @@ class _NotificationTestScreenState extends State<NotificationTestScreen> {
           setState(() {
             _fcmToken = token;
           });
-          _addLog('✅ Token FCM récupéré: ${token.substring(0, 20)}...');
+          final tokenPreview = token.length > 20 ? token.substring(0, 20) : token;
+          _addLog('✅ Token FCM récupéré: $tokenPreview...');
         } else {
           _addLog('⚠️ Aucun token FCM trouvé, génération...');
           final newToken = await _webNotificationService!.generateFCMToken();
           setState(() {
             _fcmToken = newToken;
           });
-          _addLog('✅ Nouveau token généré: ${newToken?.substring(0, 20) ?? 'erreur'}...');
+          final tokenPreview = newToken != null && newToken.length > 20
+              ? newToken.substring(0, 20)
+              : (newToken ?? 'erreur');
+          _addLog('✅ Nouveau token généré: $tokenPreview...');
         }
       }
     } catch (e) {


### PR DESCRIPTION
Corrections pour résoudre les erreurs de permissions et null check sur iOS:
- Ajouter fallback callback-based API pour Notification.requestPermission (iOS)
- Améliorer la détection de plateforme (iOS, PWA, standalone)
- Ajouter gestion robuste des erreurs avec try/catch multiples
- Corriger null check operator sur token substring
- Ajouter vérifications de longueur avant substring()

Résout les erreurs:
- NoSuchMethodError: method not found: 'permissions'
- NoSuchMethodError: method not found: 'requestPermission'
- Null check operator used on a null value