### PR TITLE
fix: Afficher la date de création au lieu de la date de modification …

### DIFF
--- a/lib/presentation/notes/notes_screen.dart
+++ b/lib/presentation/notes/notes_screen.dart
@@ -290,18 +290,18 @@ class _NotesScreenState extends State<NotesScreen> {
 
   Widget _buildNoteCard(Note note) {
     debugPrint('🎨 Rendu carte: "${note.content}"');
-    
-    // Format date style Google Keep
+
+    // Format date style Google Keep - utiliser la date de création
     final now = DateTime.now();
-    final difference = now.difference(note.updatedAt);
+    final difference = now.difference(note.createdAt);
     String formattedDate;
-    
+
     if (difference.inDays == 0) {
-      formattedDate = '${note.updatedAt.hour.toString().padLeft(2, '0')}:${note.updatedAt.minute.toString().padLeft(2, '0')}';
+      formattedDate = '${note.createdAt.hour.toString().padLeft(2, '0')}:${note.createdAt.minute.toString().padLeft(2, '0')}';
     } else if (difference.inDays < 7) {
       formattedDate = '${difference.inDays}j';
     } else {
-      formattedDate = '${note.updatedAt.day}/${note.updatedAt.month}';
+      formattedDate = '${note.createdAt.day}/${note.createdAt.month}';
     }
 
     return GestureDetector(


### PR DESCRIPTION
…pour les notes

- Corriger notes_screen.dart pour utiliser note.createdAt au lieu de note.updatedAt
- L'affichage de la date dans la liste des notes montre maintenant la date de création
- note_edit_screen.dart continue d'afficher la date de modification (comportement correct)