### PR TITLE
fix: Afficher la date de création au lieu de la date de modification …

### DIFF
--- a/lib/presentation/notes/notes_screen.dart
+++ b/lib/presentation/notes/notes_screen.dart
@@ -290,18 +290,18 @@ class _NotesScreenState extends State<NotesScreen> {
 
   Widget _buildNoteCard(Note note) {
     debugPrint('🎨 Rendu carte: "${note.content}"');
-    
-    // Format date style Google Keep
+
+    // Format date style Google Keep - utiliser la date de création
     final now = DateTime.now();
-    final difference = now.difference(note.updatedAt);
+    final difference = now.difference(note.createdAt);
     String formattedDate;
-    
+
     if (difference.inDays == 0) {
-      formattedDate = '${note.updatedAt.hour.toString().padLeft(2, '0')}:${note.updatedAt.minute.toString().padLeft(2, '0')}';
+      formattedDate = '${note.createdAt.hour.toString().padLeft(2, '0')}:${note.createdAt.minute.toString().padLeft(2, '0')}';
     } else if (difference.inDays < 7) {
       formattedDate = '${difference.inDays}j';
     } else {
-      formattedDate = '${note.updatedAt.day}/${note.updatedAt.month}';
+      formattedDate = '${note.createdAt.day}/${note.createdAt.month}';
     }
 
     return GestureDetector(
@@ -365,13 +365,13 @@ class _NotesScreenState extends State<NotesScreen> {
             
             SizedBox(height: 2.w),
             
-            // Ligne du bas : date modifiée
+            // Ligne du bas : date de création
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                // Date modifiée
+                // Date de création
                 Text(
-                  'Modifié : $formattedDate',
+                  'Créée : $formattedDate',
                   style: TextStyle(
                     color: Color(0xFF5F6368),
                     fontSize: 10.sp,

--- a/lib/presentation/notes/widgets/note_card_widget.dart
+++ b/lib/presentation/notes/widgets/note_card_widget.dart
@@ -189,7 +189,7 @@ class NoteCardWidget extends StatelessWidget {
 
                 SizedBox(height: 1.5.h),
 
-                // Footer: Date de modification
+                // Footer: Date de création
                 Row(
                   children: [
                     Icon(


### PR DESCRIPTION
…pour les notes

- Corriger notes_screen.dart pour utiliser note.createdAt au lieu de note.updatedAt
- Changer le texte de "Modifié :" à "Créée :" dans l'affichage
- Mettre à jour les commentaires de "Date de modification" à "Date de création"
- note_edit_screen.dart continue d'afficher la date de modification (comportement correct pour l'éditeur)