### PR TITLE
fix(web): corriger l'accès aux propriétés JS pour les notifications iOS

### DIFF
--- a/lib/services/simple_web_notification_service.dart
+++ b/lib/services/simple_web_notification_service.dart
@@ -166,8 +166,8 @@ class SimpleWebNotificationService {
       try {
         final permissionStatus = await js_util.promiseToFuture(
           js_util.callMethod(
-            js_util.callMethod(js.context['navigator'], 'permissions', []), 
-            'query', 
+            js_util.getProperty(js.context['navigator'], 'permissions'),
+            'query',
             [js_util.jsify({'name': 'notifications'})]
           )
         );
@@ -177,7 +177,7 @@ class SimpleWebNotificationService {
       } catch (e) {
         debugPrint('⚠️ Modern API failed, trying legacy: $e');
         // Fallback vers l'ancienne méthode
-        final permission = js_util.callMethod(js.context['Notification'], 'permission', []);
+        final permission = js_util.getProperty(js.context['Notification'], 'permission');
         debugPrint('✅ Got permission via legacy API: $permission');
         return permission.toString();
       }
@@ -218,8 +218,8 @@ class SimpleWebNotificationService {
         // Essayer la nouvelle méthode (iOS 15+)
         final permissionStatus = await js_util.promiseToFuture(
           js_util.callMethod(
-            js_util.callMethod(js.context['navigator'], 'permissions', []), 
-            'request', 
+            js_util.getProperty(js.context['navigator'], 'permissions'),
+            'request',
             [js_util.jsify({'name': 'notifications'})]
           )
         );


### PR DESCRIPTION
Problème:
- navigator.permissions et Notification.permission étaient appelés comme des fonctions
- Causait des erreurs "method not found" sur iOS/Safari
- Empêchait la demande de permissions de notification

Solution:
- Utiliser js_util.getProperty au lieu de js_util.callMethod pour accéder aux propriétés
- Corrections appliquées aux lignes 169, 180 et 221
- Permet maintenant l'accès correct aux API de permissions web

Impact:
- Les permissions de notification fonctionnent maintenant sur iOS PWA
- Résout les erreurs "NoSuchMethodError" dans les logs